### PR TITLE
drop .$argv[0] in $lock_file

### DIFF
--- a/lock.helper.php
+++ b/lock.helper.php
@@ -17,7 +17,7 @@
 		public static function lock() {
 			global $argv;
 
-			$lock_file = LOCK_DIR.$argv[0].LOCK_SUFFIX;
+			$lock_file = LOCK_DIR.LOCK_SUFFIX; // NBP 2/2/2020 drop .$argv[0]
 
 			if(file_exists($lock_file)) {
 				//return FALSE;
@@ -45,7 +45,7 @@
 		public static function unlock() {
 			global $argv;
 
-			$lock_file = LOCK_DIR.$argv[0].LOCK_SUFFIX;
+			$lock_file = LOCK_DIR.LOCK_SUFFIX; // NBP 2/2/2020 drop .$argv[0]
 
 			if(file_exists($lock_file))
 				unlink($lock_file);


### PR DESCRIPTION
using the $argv[0] creates an illegal file path name, clean up illegal file path
PHP warning file_put_contents(/tmp//home/fpp/media/plugins/FPP-Plugin-Matrix-Message/matrix.phpFPP-Plugin-Matrix-Message.lock), failed to open stream, no such file or directory lockhelper.php
fix for lines 20 & 48