### PR TITLE
update $messageQueue_Plugin for FPP v3.x

### DIFF
--- a/matrix.php
+++ b/matrix.php
@@ -24,10 +24,10 @@ include_once("commonFunctions.inc.php");
 require ("lock.helper.php");
 define('LOCK_DIR', '/tmp/');
 define('LOCK_SUFFIX', $pluginName.'.lock');
-$messageQueue_Plugin = "MessageQueue";
-if (strpos($pluginName, "FPP-Plugin") !== false) {
-    $messageQueue_Plugin = "FPP-Plugin-MessageQueue";
-}
+$messageQueue_Plugin = "FPP-Plugin-MessageQueue"; // NBP 2/2/2020
+//if (strpos($pluginName, "FPP-Plugin") !== false) {
+//    $messageQueue_Plugin = "FPP-Plugin-MessageQueue";
+//}
 $MESSAGE_QUEUE_PLUGIN_ENABLED=false;
 
 $fpp_matrixtools_Plugin = "fpp-matrixtools";


### PR DESCRIPTION
lines 27 - 30, fix plugin name to match FPP v3.x
odd typo on "if (strpos($pluginName, "FPP-Plugin") !== false)" the "!==" should be "!=" or "=="
felt it was better just to drop the extra name checking and set $messageQueue_Plugin for current naming